### PR TITLE
Swap to restore from maximize when restoring the window

### DIFF
--- a/electron/communicationBridge/customCommandReceiver.ts
+++ b/electron/communicationBridge/customCommandReceiver.ts
@@ -61,7 +61,7 @@ function toggleMaximize({ window }: { window: BrowserWindow }) {
   if (window.isMaximized()) {
     window.unmaximize();
   } else {
-    window.maximize();
+    window.restore();
   }
 }
 


### PR DESCRIPTION
restore should return the timer to the original state per [electron documentation](https://www.electronjs.org/docs/latest/api/browser-window#winrestore). This still needs to be tested.