### PR TITLE
Add window size persistence and 30-second timer increments

### DIFF
--- a/electron/communicationBridge/customCommandReceiver.ts
+++ b/electron/communicationBridge/customCommandReceiver.ts
@@ -2,8 +2,26 @@ import { BrowserWindow, screen, ipcMain } from 'electron';
 import { customCommandChannelName } from './constants';
 import { app } from 'electron';
 
-// Store the window size before maximizing
-let savedWindowSize: { width: number; height: number } | null = null;
+// Store the window size and position before maximizing
+let savedWindowState: { 
+  width: number; 
+  height: number;
+  x: number;
+  y: number;
+} | null = null;
+
+// Flag to ignore programmatic resize events
+// We'll use a regular variable since we don't have direct access to globals
+let isProgrammaticResize = false;
+
+// Functions to access and modify the flag
+const getProgrammaticResize = () => isProgrammaticResize;
+const setProgrammaticResize = (value: boolean) => {
+  isProgrammaticResize = value;
+};
+
+// Export the function for other modules to use
+export const setProgrammaticResizeState = setProgrammaticResize;
 
 export function createCustomCommandReceiver({
   window,
@@ -11,12 +29,41 @@ export function createCustomCommandReceiver({
   window: BrowserWindow;
 }) {
   // Listen for window resize events to track manual resizing by the user
+  let lastResizeTimeStamp = 0;
+  
   window.on('resize', () => {
-    // Only save size if window is not maximized to avoid saving fullscreen dimensions
-    if (!window.isMaximized()) {
+    // Get current timestamp for throttling
+    const now = Date.now();
+    
+    // Only save size if it's not a programmatic resize, not maximized, and not throttled
+    if (!getProgrammaticResize() && !window.isMaximized() && (now - lastResizeTimeStamp > 100)) {
       const [width, height] = window.getSize();
-      savedWindowSize = { width, height };
-      console.log('Window resized by user, saved size:', savedWindowSize);
+      
+      // Don't save timer overlay sizes
+      const isTooSmall = width <= 300 && height <= 300;
+      
+      if (!isTooSmall) {
+        // Get current position
+        const [x, y] = window.getPosition();
+        
+        // Save both size and position
+        savedWindowState = { width, height, x, y };
+        console.log('Window resized by user, saved state:', savedWindowState);
+      } else {
+        console.log('Window too small, likely a timer overlay. Not saving size.');
+      }
+      
+      // Update timestamp
+      lastResizeTimeStamp = now;
+    } else {
+      // For clarity in the logs
+      if (getProgrammaticResize()) {
+        console.log('Ignoring programmatic resize event');
+      } else if (window.isMaximized()) {
+        console.log('Ignoring resize event for maximized window');
+      } else {
+        console.log('Ignoring throttled resize event');
+      }
     }
   });
 
@@ -41,6 +88,9 @@ export function createCustomCommandReceiver({
       case 'restore-window-size':
         restoreWindowSize({ window });
         break;
+      case 'restore-window-size-and-reposition':
+        restoreWindowSizeAndReposition({ window });
+        break;
       default:
         console.warn('UH OH no command found for: ', message);
         break;
@@ -49,39 +99,163 @@ export function createCustomCommandReceiver({
 }
 
 function saveWindowSize({ window }: { window: BrowserWindow }) {
+  // Don't save if window is maximized - we're only interested in custom sizes
   if (!window.isMaximized()) {
     const [width, height] = window.getSize();
-    savedWindowSize = { width, height };
-    console.log('Saved window size:', savedWindowSize);
+    const [x, y] = window.getPosition();
+    
+    // Also don't save super small sizes that are likely the timer overlay
+    // Timer overlay is 240x240, so we'll use 300 as a threshold
+    const isLikelyTimerOverlay = width <= 300 && height <= 300;
+    
+    if (!isLikelyTimerOverlay) {
+      savedWindowState = { width, height, x, y };
+      console.log('Explicitly saved window state:', savedWindowState);
+    } else {
+      console.log('Not saving timer overlay size');
+    }
+  } else {
+    console.log('Not saving maximized window size');
   }
 }
 
 function restoreWindowSize({ window }: { window: BrowserWindow }) {
-  if (savedWindowSize) {
-    window.unmaximize();
-    window.setSize(savedWindowSize.width, savedWindowSize.height);
-    console.log('Restored window size to:', savedWindowSize);
+  if (savedWindowState) {
+    console.log('Restoring window state to:', savedWindowState);
+    
+    // Set flag to ignore resize events during this operation
+    setProgrammaticResize(true);
+    
+    // First unmaximize if it's maximized
+    const wasMaximized = window.isMaximized();
+    if (wasMaximized) {
+      window.unmaximize();
+      console.log('Window was maximized, unmaximizing first');
+    }
+    
+    // Restore in steps with appropriate delays to ensure correct sequencing
+    setTimeout(() => {
+      if (savedWindowState) { // Double-check savedWindowState is still defined
+        // First restore width and height
+        window.setSize(savedWindowState.width, savedWindowState.height);
+        
+        // Then restore position
+        window.setPosition(savedWindowState.x, savedWindowState.y);
+        
+        // Log success
+        console.log('Successfully restored window state to:', savedWindowState);
+        
+        // Move to a visible position if needed
+        setTimeout(() => {
+          const display = screen.getDisplayMatching(window.getBounds());
+          const bounds = window.getBounds();
+          
+          // Check if window is off-screen
+          const isOffScreenX = bounds.x < 0 || bounds.x > display.bounds.width;
+          const isOffScreenY = bounds.y < 0 || bounds.y > display.bounds.height;
+          
+          if (isOffScreenX || isOffScreenY) {
+            // Center the window if it's off-screen
+            window.center();
+            console.log('Window was off-screen, centering it');
+          }
+          
+          // Reset flag after all operations complete
+          setProgrammaticResize(false);
+        }, 100);
+      } else {
+        setProgrammaticResize(false);
+      }
+    }, 100);
+  } else {
+    console.log('No saved window state to restore');
+  }
+}
+
+function restoreWindowSizeAndReposition({ window }: { window: BrowserWindow }) {
+  // This function is specifically for the timer overlay, so we should always
+  // position at the bottom right corner regardless of previous position
+  
+  if (savedWindowState) {
+    console.log('Restoring window size and repositioning to bottom right:', savedWindowState.width, 'x', savedWindowState.height);
+    
+    // Set flag to ignore resize events during this operation
+    setProgrammaticResize(true);
+    
+    // First unmaximize if it's maximized
+    const wasMaximized = window.isMaximized();
+    if (wasMaximized) {
+      window.unmaximize();
+      console.log('Window was maximized, unmaximizing first');
+    }
+    
+    // Then set the size with a longer delay to ensure unmaximize completed
+    setTimeout(() => {
+      if (savedWindowState) { // Double-check savedWindowState is still defined
+        // Set the size first
+        window.setSize(savedWindowState.width, savedWindowState.height);
+        console.log('Restored window size to:', savedWindowState.width, 'x', savedWindowState.height);
+        
+        // Give a longer delay to ensure the window size is properly set before repositioning
+        setTimeout(() => {
+          const display = screen.getDisplayMatching(window.getBounds());
+          const x = display.workArea.x + display.workAreaSize.width - window.getSize()[0];
+          const y = display.workArea.y + display.workAreaSize.height - window.getSize()[1];
+          
+          // Always position at bottom right for this specific function,
+          // ignoring the saved position
+          window.setPosition(x, y);
+          console.log('Repositioned window to bottom right at:', x, y);
+          
+          // Reset flag after all operations complete
+          setProgrammaticResize(false);
+        }, 100);
+      } else {
+        setProgrammaticResize(false);
+      }
+    }, 150);
+  } else {
+    // If no saved size, still position at bottom right with default size
+    console.log('No saved window state, using default size and position');
+    moveWindowToBottomRight({ window });
   }
 }
 
 function moveWindowToBottomRight({ window }: { window: BrowserWindow }) {
+  // Set flag to ignore resize events during this operation
+  setProgrammaticResize(true);
+  
   const display = screen.getDisplayMatching(window.getBounds());
   const x =
     display.workArea.x + display.workAreaSize.width - window.getSize()[0];
   const y =
     display.workArea.y + display.workAreaSize.height - window.getSize()[1];
   window.setPosition(x, y);
+  
+  // Reset flag after a delay to ensure operation completes
+  setTimeout(() => {
+    setProgrammaticResize(false);
+  }, 50);
 }
 
 function moveWindowToBottomLeft({ window }: { window: BrowserWindow }) {
+  // Set flag to ignore resize events during this operation
+  setProgrammaticResize(true);
+  
   const display = screen.getDisplayMatching(window.getBounds());
   const x = display.workArea.x;
   const y =
     display.workArea.y + display.workAreaSize.height - window.getSize()[1];
   window.setPosition(x, y);
+  
+  // Reset flag after a delay to ensure operation completes
+  setTimeout(() => {
+    setProgrammaticResize(false);
+  }, 50);
 }
 
 function moveWindowToOppositeCorner({ window }: { window: BrowserWindow }) {
+  // The child functions will set and clear the flag
   const display = screen.getDisplayMatching(window.getBounds());
   const displayCenterLine = display.workArea.x + display.workArea.width / 2;
   const [currentWindowX] = window.getPosition();
@@ -93,11 +267,19 @@ function moveWindowToOppositeCorner({ window }: { window: BrowserWindow }) {
 }
 
 function toggleMaximize({ window }: { window: BrowserWindow }) {
+  // Set flag to ignore resize events during this operation
+  setProgrammaticResize(true);
+  
   if (window.isMaximized()) {
     window.unmaximize();
   } else {
     window.maximize();
   }
+  
+  // Reset flag after a delay to ensure operation completes
+  setTimeout(() => {
+    setProgrammaticResize(false);
+  }, 100);
 }
 
 function focus() {

--- a/electron/communicationBridge/mainCommunicationBridge.ts
+++ b/electron/communicationBridge/mainCommunicationBridge.ts
@@ -1,6 +1,9 @@
 import { BrowserWindow, ipcMain } from 'electron';
 import { mainCommChannelName } from './constants';
 
+// Import the customCommandReceiver
+import { setProgrammaticResizeState } from './customCommandReceiver';
+
 export function createWindowBrowserReceiver({
   window,
 }: {
@@ -10,7 +13,42 @@ export function createWindowBrowserReceiver({
     mainCommChannelName,
     async (_metadata, message: { functionName: string; arguments: any[] }) => {
       console.log(`${mainCommChannelName} received message: `, message);
-      await (window as any)[message.functionName](...message.arguments);
+      
+      // Handle window resize operations specially
+      const resizeFunctions = ['setSize', 'setContentSize', 'maximize', 'unmaximize', 'restore'];
+      
+      if (resizeFunctions.includes(message.functionName)) {
+        console.log(`Performing programmatic resize: ${message.functionName}`, message.arguments);
+        
+        // If the external function exists, use it
+        // If not, we'll just proceed with the resize
+        try {
+          if (typeof setProgrammaticResizeState === 'function') {
+            // Set the flag for programmatic resize
+            setProgrammaticResizeState(true);
+          }
+        } catch (e) {
+          console.error('Failed to access resize state:', e);
+        }
+        
+        // Execute the resize operation
+        await (window as any)[message.functionName](...message.arguments);
+        
+        // Reset the flag after a delay
+        setTimeout(() => {
+          try {
+            if (typeof setProgrammaticResizeState === 'function') {
+              // Reset the flag
+              setProgrammaticResizeState(false);
+            }
+          } catch (e) {
+            console.error('Failed to reset resize state:', e);
+          }
+        }, 100);
+      } else {
+        // For non-resize functions, just execute them directly
+        await (window as any)[message.functionName](...message.arguments);
+      }
     },
   );
 }

--- a/src/pages/EditEnsemble.tsx
+++ b/src/pages/EditEnsemble.tsx
@@ -77,7 +77,11 @@ function EnsembleOptions() {
     setRotationsPerBreak: state.setRotationsPerBreak,
   }));
 
-  const timerLengthInMinutes = Math.round(timerLength / (60 * 1000));
+  // Display time in minutes and seconds
+  const timerMinutes = Math.floor(timerLength / (60 * 1000));
+  const timerSeconds = (timerLength % (60 * 1000)) / 1000;
+  const timerDisplay = timerSeconds > 0 ? `${timerMinutes}:${timerSeconds === 30 ? '30' : '00'}` : `${timerMinutes}`;
+  
   const breakLengthInMinutes = Math.round(breakLength / (60 * 1000));
   return (
     <>
@@ -90,49 +94,62 @@ function EnsembleOptions() {
           <div className="mt-2">
             <Button
               onClick={() => {
-                setTimerLength(timerLength - 60 * 1000);
+                // Reduce by 30 seconds
+                setTimerLength(timerLength - 30 * 1000);
               }}
-              disabled={timerLengthInMinutes <= 1}
+              // Allow a minimum of 30 seconds
+              disabled={timerLength <= 30 * 1000}
               className="hover:bg-zinc-700"
             >
               <MinusIcon />
             </Button>
-            <div className="inline h-10 w-10">
-              <p className="text-2xl mx-3 inline h-10 w-10">
-                {timerLengthInMinutes}
+            <div className="inline h-10 w-16">
+              <p className="text-2xl mx-3 inline h-10 w-16">
+                {timerDisplay}
               </p>
             </div>
             <Button
               onClick={() => {
-                setTimerLength(timerLength + 60 * 1000);
+                // Increase by 30 seconds
+                setTimerLength(timerLength + 30 * 1000);
               }}
               className="hover:bg-zinc-700"
             >
               <PlusIcon />
             </Button>
-            <span className="text-2xl ml-3">Minutes</span>
+            <span className="text-2xl ml-3">{timerSeconds > 0 ? 'Min:Sec' : 'Minutes'}</span>
           </div>
           <h1 className="mt-3 text-2xl">Breaks</h1>
           <div className="mt-2">
             <Button
               className="hover:bg-zinc-700"
               onClick={() => {
-                setBreakLength(breakLength - 60 * 1000);
+                setBreakLength(breakLength - 30 * 1000);
               }}
-              disabled={breakLengthInMinutes <= 1}
+              disabled={breakLength <= 30 * 1000}
             >
               <MinusIcon />
             </Button>
-            <span className="text-2xl mx-3">{breakLengthInMinutes}</span>
+            <div className="inline h-10 w-16">
+              {breakLength % (60 * 1000) === 0 ? (
+                <span className="text-2xl mx-3">{Math.floor(breakLength / (60 * 1000))}</span>
+              ) : (
+                <span className="text-2xl mx-3">
+                  {Math.floor(breakLength / (60 * 1000))}:30
+                </span>
+              )}
+            </div>
             <Button
               className="hover:bg-zinc-700"
               onClick={() => {
-                setBreakLength(breakLength + 60 * 1000);
+                setBreakLength(breakLength + 30 * 1000);
               }}
             >
               <PlusIcon />
             </Button>
-            <span className="text-2xl ml-3">Minutes</span>
+            <span className="text-2xl ml-3">
+              {breakLength % (60 * 1000) === 0 ? "Minutes" : "Min:Sec"}
+            </span>
           </div>
           <div className="mt-2">
             <Button
@@ -154,7 +171,7 @@ function EnsembleOptions() {
               <PlusIcon />
             </Button>
             <span className="text-2xl ml-3">
-              Every {rotationsPerBreak * timerLengthInMinutes} Minutes
+              Every {rotationsPerBreak * timerMinutes + (timerSeconds > 0 ? rotationsPerBreak * 0.5 : 0)} Minutes
             </span>
           </div>
         </CardContent>

--- a/src/pages/Handoff.tsx
+++ b/src/pages/Handoff.tsx
@@ -15,11 +15,20 @@ import {
   useAppStore,
 } from '@/state.ts/defaultState';
 import { useEffect } from 'react';
-import { transitionToFullscreen } from '@/windowUtils/fullscreen';
+import { transitionToFullscreen, transitionFromTimer } from '@/windowUtils/fullscreen';
 
 export function Handoff() {
   useEffect(() => {
-    transitionToFullscreen();
+    // Check if we're coming from timer mode
+    const { previousMode } = useAppStore.getState();
+    
+    if (previousMode === 'timer') {
+      // If coming from timer, try to restore previous size
+      transitionFromTimer();
+    } else {
+      // Otherwise use full screen
+      transitionToFullscreen();
+    }
   }, []);
 
   const {

--- a/src/pages/TimerOverlay.tsx
+++ b/src/pages/TimerOverlay.tsx
@@ -35,7 +35,18 @@ export function TimerOverlay() {
   useEffect(() => {
     RendererWindowBrowser.restore();
     RendererWindowBrowser.setOpacity(0.5);
-    RendererWindowBrowser.setSize(240, 240);
+    
+    // Check if we should use a default size or restore previous size
+    sendMessage({
+      channel: customCommandChannelName,
+      message: 'restore-window-size',
+    });
+    
+    // Set the overlay size as fallback if no saved size
+    setTimeout(() => {
+      RendererWindowBrowser.setSize(240, 240);
+    }, 100);
+    
     RendererWindowBrowser.setAlwaysOnTop(true);
     sendMessage({
       channel: customCommandChannelName,
@@ -44,6 +55,11 @@ export function TimerOverlay() {
 
     const exitTimer = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        // Save window size before exiting timer
+        sendMessage({
+          channel: customCommandChannelName,
+          message: 'save-window-size',
+        });
         goToEdit();
       }
     };

--- a/src/pages/TimerOverlay.tsx
+++ b/src/pages/TimerOverlay.tsx
@@ -33,34 +33,40 @@ export function TimerOverlay() {
   }));
 
   useEffect(() => {
+    // Flag that we're about to do a programmatic resize
+    console.log('Initializing timer overlay');
+    
+    // First restore window (in case it was maximized)
     RendererWindowBrowser.restore();
+    
+    // Set window properties
     RendererWindowBrowser.setOpacity(0.5);
-    
-    // Check if we should use a default size or restore previous size
-    sendMessage({
-      channel: customCommandChannelName,
-      message: 'restore-window-size',
-    });
-    
-    // Set the overlay size as fallback if no saved size
-    setTimeout(() => {
-      RendererWindowBrowser.setSize(240, 240);
-    }, 100);
-    
     RendererWindowBrowser.setAlwaysOnTop(true);
-    sendMessage({
-      channel: customCommandChannelName,
-      message: 'move-to-bottom-right',
-    });
+    
+    // Set the fixed timer overlay size - this should always be 240x240
+    RendererWindowBrowser.setSize(240, 240);
+    
+    // Always position in bottom right
+    setTimeout(() => {
+      sendMessage({
+        channel: customCommandChannelName,
+        message: 'move-to-bottom-right',
+      });
+    }, 50);
 
     const exitTimer = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        // Save window size before exiting timer
+        // First save the current window size explicitly
+        console.log('Saving window size before exiting timer');
         sendMessage({
           channel: customCommandChannelName,
           message: 'save-window-size',
         });
-        goToEdit();
+        
+        // Small delay to ensure the size is saved before transitioning
+        setTimeout(() => {
+          goToEdit();
+        }, 50);
       }
     };
     document.addEventListener('keydown', exitTimer);

--- a/src/pages/WantABreak.tsx
+++ b/src/pages/WantABreak.tsx
@@ -3,11 +3,20 @@ import { CoffeeIcon } from '@/components/icons/icons';
 import { Button } from '@/components/ui/button';
 import { useAppStore } from '@/state.ts/defaultState';
 import { useEffect } from 'react';
-import { transitionToFullscreen } from '@/windowUtils/fullscreen';
+import { transitionToFullscreen, transitionFromTimer } from '@/windowUtils/fullscreen';
 
 export function WantABreak() {
   useEffect(() => {
-    transitionToFullscreen();
+    // Check if we're coming from timer mode
+    const { previousMode } = useAppStore.getState();
+    
+    if (previousMode === 'timer') {
+      // If coming from timer, try to restore previous size
+      transitionFromTimer();
+    } else {
+      // Otherwise use full screen
+      transitionToFullscreen();
+    }
   }, []);
 
   const { takeBreak, skipBreak } = useAppStore((state) => ({

--- a/src/windowUtils/fullscreen.ts
+++ b/src/windowUtils/fullscreen.ts
@@ -2,7 +2,18 @@ import { RendererWindowBrowser } from '@/communicationBridge/fakeWindowBrowser';
 import { sendMessage } from '@/communicationBridge/rendererCommunicationBridge';
 import { customCommandChannelName } from '../../electron/communicationBridge/constants';
 
+export function saveCurrentWindowSize() {
+  sendMessage({ channel: customCommandChannelName, message: 'save-window-size' });
+}
+
+export function restoreLastWindowSize() {
+  sendMessage({ channel: customCommandChannelName, message: 'restore-window-size' });
+}
+
 export function transitionToFullscreen() {
+  // Save the current window size before maximizing
+  sendMessage({ channel: customCommandChannelName, message: 'save-window-size' });
+  
   RendererWindowBrowser.setOpacity(1.0);
   RendererWindowBrowser.focus();
   sendMessage({ channel: customCommandChannelName, message: 'focus' });

--- a/src/windowUtils/fullscreen.ts
+++ b/src/windowUtils/fullscreen.ts
@@ -10,6 +10,7 @@ export function restoreLastWindowSize() {
   sendMessage({ channel: customCommandChannelName, message: 'restore-window-size' });
 }
 
+// Original function that always maximizes
 export function transitionToFullscreen() {
   // Save the current window size before maximizing
   sendMessage({ channel: customCommandChannelName, message: 'save-window-size' });
@@ -21,5 +22,24 @@ export function transitionToFullscreen() {
   RendererWindowBrowser.setAlwaysOnTop(true);
   setTimeout(() => {
     RendererWindowBrowser.setAlwaysOnTop(false); // When the driver switches make sure no other window takes the spotlight for a brief period.
+  }, 1500);
+}
+
+// New function that tries to restore the previous size if coming from timer
+export function transitionFromTimer() {
+  console.log('Transitioning from timer, will try to restore previous size');
+  
+  // Make window opaque and focused
+  RendererWindowBrowser.setOpacity(1.0);
+  RendererWindowBrowser.focus();
+  sendMessage({ channel: customCommandChannelName, message: 'focus' });
+  
+  // Try to restore previous size instead of maximizing
+  sendMessage({ channel: customCommandChannelName, message: 'restore-window-size' });
+  
+  // Still ensure it's visible and active
+  RendererWindowBrowser.setAlwaysOnTop(true);
+  setTimeout(() => {
+    RendererWindowBrowser.setAlwaysOnTop(false);
   }, 1500);
 }


### PR DESCRIPTION
## Summary
- Add ability to save and restore window size when user manually resizes the window
- Add window size persistence across timer sessions
- Modify timer UI to allow 30-second increments for both timer and breaks
- Update display format to show time in min:sec format when appropriate
- Lower minimum timer and break time to 30 seconds

## Test plan
- Verify timer window size is preserved when manually resized
- Verify timer allows 30-second increments
- Verify timer display shows seconds correctly
- Verify minimum time can be set to 30 seconds

🤖 Generated with [Claude Code](https://claude.ai/code)