### PR TITLE
Add vibe coding mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Ensemble Timer Development Guide
+
+## Commands
+- Build: `npm run build`
+- Dev: `npm run dev`
+- Lint: `npm run lint`
+- E2E Tests: `npm run test:e2e`
+- Window Size Tests: `npm run test:window-size`
+- Simple Tests: `npm run test:simple`
+- Direct Window Test: `npm run test:direct`
+- Window Debug: `npm run debug:window`
+
+## Code Style Guidelines
+- TypeScript with strict type checking
+- React functional components preferred
+- File naming: PascalCase for components, camelCase for utilities
+- State management via Zustand
+- Styling: Tailwind CSS with shadcn/ui components
+- ESLint standard React/TS rules
+- Prettier: single quotes, semicolons, 80-char width
+- Electron IPC channels for main/renderer communication
+
+## Architecture
+- Electron app with main and renderer processes
+- Custom ipc bridge for cross-process communication
+- Recent focus: window size persistence and positioning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # Ensemble Timer Development Guide
 
 ## Commands
+
 - Build: `npm run build`
 - Dev: `npm run dev`
 - Lint: `npm run lint`
@@ -11,6 +12,7 @@
 - Window Debug: `npm run debug:window`
 
 ## Code Style Guidelines
+
 - TypeScript with strict type checking
 - React functional components preferred
 - File naming: PascalCase for components, camelCase for utilities
@@ -21,6 +23,12 @@
 - Electron IPC channels for main/renderer communication
 
 ## Architecture
+
 - Electron app with main and renderer processes
 - Custom ipc bridge for cross-process communication
 - Recent focus: window size persistence and positioning
+
+## GitHub
+
+- The workspace may be a fork of the open-source https://github.com/zachrog/ensemble-timer.git
+- Pull requests (PRs) are created against the upstream remote

--- a/src/components/icons/icons.tsx
+++ b/src/components/icons/icons.tsx
@@ -206,3 +206,27 @@ export function DiceIcon({ className = 'w-5 h-5' }: { className?: string }) {
     </svg>
   );
 }
+
+export function VibeModeIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      {/* Cool sunglasses frame */}
+      <path d="M1,11 C1,9.5 2,8 3.5,8 L7,8 C9,8 9.5,9 10,10 L14,10 C14.5,9 15,8 17,8 L20.5,8 C22,8 23,9.5 23,11 L23,12 C23,13 22.5,15 20,15 L17,15 C14.5,15 14,13 14,12 L10,12 C10,13 9.5,15 7,15 L4,15 C1.5,15 1,13 1,12 L1,11 Z" />
+      
+      {/* Left lens */}
+      <circle cx="7" cy="11.5" r="2.5" fill="#000" />
+      
+      {/* Right lens */}
+      <circle cx="17" cy="11.5" r="2.5" fill="#000" />
+      
+      {/* Cool reflections on lenses */}
+      <path d="M6,10.5 L8,12.5" stroke="#fff" strokeWidth="0.5" />
+      <path d="M16,10.5 L18,12.5" stroke="#fff" strokeWidth="0.5" />
+    </svg>
+  );
+}

--- a/src/components/icons/icons.tsx
+++ b/src/components/icons/icons.tsx
@@ -207,14 +207,18 @@ export function DiceIcon({ className = 'w-5 h-5' }: { className?: string }) {
   );
 }
 
-export function VibeModeIcon({ className = 'w-5 h-5' }: { className?: string }) {
+export function VibeModeIcon({ className = 'w-5 h-5', title = 'Vibe Mode' }: { className?: string, title?: string }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
       fill="currentColor"
       className={className}
+      aria-hidden="false"
+      role="img"
+      aria-labelledby="vibeModeTitle"
     >
+      <title id="vibeModeTitle">{title}</title>
       {/* Cool sunglasses frame */}
       <path d="M1,11 C1,9.5 2,8 3.5,8 L7,8 C9,8 9.5,9 10,10 L14,10 C14.5,9 15,8 17,8 L20.5,8 C22,8 23,9.5 23,11 L23,12 C23,13 22.5,15 20,15 L17,15 C14.5,15 14,13 14,12 L10,12 C10,13 9.5,15 7,15 L4,15 C1.5,15 1,13 1,12 L1,11 Z" />
       

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-interface ToggleProps extends React.HTMLAttributes<HTMLDivElement> {
+interface ToggleProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
   disabled?: boolean;
+  label?: string;
 }
 
 export function Toggle({
@@ -12,29 +13,44 @@ export function Toggle({
   onCheckedChange,
   disabled = false,
   className,
+  label,
   ...props
 }: ToggleProps) {
   return (
-    <div
-      onClick={() => {
-        if (!disabled) {
-          onCheckedChange(!checked);
-        }
-      }}
+    <label
       className={cn(
-        'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
-        checked ? 'bg-emerald-600' : 'bg-zinc-700',
-        disabled && 'opacity-50 cursor-not-allowed',
+        'flex items-center',
         className
       )}
-      {...props}
     >
-      <span
-        className={cn(
-          'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
-          checked ? 'translate-x-5' : 'translate-x-0'
-        )}
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={() => {
+          if (!disabled) {
+            onCheckedChange(!checked);
+          }
+        }}
+        disabled={disabled}
+        className="sr-only"
+        {...props}
       />
-    </div>
+      <div
+        className={cn(
+          'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
+          checked ? 'bg-emerald-600' : 'bg-zinc-700',
+          disabled && 'opacity-50 cursor-not-allowed'
+        )}
+        role="presentation"
+      >
+        <span
+          className={cn(
+            'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+            checked ? 'translate-x-5' : 'translate-x-0'
+          )}
+        />
+      </div>
+      {label && <span className="ml-2">{label}</span>}
+    </label>
   );
 }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface ToggleProps extends React.HTMLAttributes<HTMLDivElement> {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export function Toggle({
+  checked,
+  onCheckedChange,
+  disabled = false,
+  className,
+  ...props
+}: ToggleProps) {
+  return (
+    <div
+      onClick={() => {
+        if (!disabled) {
+          onCheckedChange(!checked);
+        }
+      }}
+      className={cn(
+        'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
+        checked ? 'bg-emerald-600' : 'bg-zinc-700',
+        disabled && 'opacity-50 cursor-not-allowed',
+        className
+      )}
+      {...props}
+    >
+      <span
+        className={cn(
+          'pointer-events-none relative inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+          checked ? 'translate-x-5' : 'translate-x-0'
+        )}
+      />
+    </div>
+  );
+}

--- a/src/pages/EditEnsemble.tsx
+++ b/src/pages/EditEnsemble.tsx
@@ -91,7 +91,7 @@ function EnsembleOptions() {
           <CardTitle className="text-4xl">Options</CardTitle>
         </CardHeader>
         <CardContent>
-          <h1 className="text-2xl">Timer</h1>
+          <h2 className="text-2xl">Timer</h2>
           <div className="mt-2">
             <Button
               onClick={() => {
@@ -117,7 +117,7 @@ function EnsembleOptions() {
             </Button>
             <span className="text-2xl ml-3">Minutes</span>
           </div>
-          <h1 className="mt-3 text-2xl">Breaks</h1>
+          <h2 className="mt-3 text-2xl">Breaks</h2>
           <div className="mt-2">
             <Button
               className="hover:bg-zinc-700"
@@ -162,16 +162,14 @@ function EnsembleOptions() {
               Every {rotationsPerBreak * timerLengthInMinutes} Minutes
             </span>
           </div>
-          <h1 className="mt-6 text-2xl">Vibe Coding Mode</h1>
+          <h2 className="mt-6 text-2xl">Vibe Coding Mode</h2>
           <div className="mt-2 flex items-center">
             <Toggle
               checked={vibeCodingMode}
               onCheckedChange={toggleVibeCodingMode}
               className="mr-3"
+              label={vibeCodingMode ? 'Only navigator, no driver' : 'Standard mode with driver and navigator'}
             />
-            <span className="text-xl">
-              {vibeCodingMode ? 'Only navigator, no driver' : 'Standard mode with driver and navigator'}
-            </span>
           </div>
         </CardContent>
       </Card>

--- a/src/pages/EditEnsemble.tsx
+++ b/src/pages/EditEnsemble.tsx
@@ -20,6 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { BreakProgress } from '@/components/BreakProgress';
 import { Separator } from '@/components/ui/separator';
+import { Toggle } from '@/components/ui/toggle';
 import { transitionToFullscreen } from '@/windowUtils/fullscreen';
 
 export function EditEnsemble() {
@@ -68,6 +69,8 @@ function EnsembleOptions() {
     setBreakLength,
     rotationsPerBreak,
     setRotationsPerBreak,
+    vibeCodingMode,
+    toggleVibeCodingMode,
   } = useAppStore((state) => ({
     timerLength: state.timerLength,
     setTimerLength: state.setTimerLength,
@@ -75,6 +78,8 @@ function EnsembleOptions() {
     setBreakLength: state.setBreakLength,
     rotationsPerBreak: state.rotationsPerBreak,
     setRotationsPerBreak: state.setRotationsPerBreak,
+    vibeCodingMode: state.vibeCodingMode,
+    toggleVibeCodingMode: state.toggleVibeCodingMode,
   }));
 
   const timerLengthInMinutes = Math.round(timerLength / (60 * 1000));
@@ -157,6 +162,17 @@ function EnsembleOptions() {
               Every {rotationsPerBreak * timerLengthInMinutes} Minutes
             </span>
           </div>
+          <h1 className="mt-6 text-2xl">Vibe Coding Mode</h1>
+          <div className="mt-2 flex items-center">
+            <Toggle
+              checked={vibeCodingMode}
+              onCheckedChange={toggleVibeCodingMode}
+              className="mr-3"
+            />
+            <span className="text-xl">
+              {vibeCodingMode ? 'Only navigator, no driver' : 'Standard mode with driver and navigator'}
+            </span>
+          </div>
         </CardContent>
       </Card>
     </>
@@ -177,6 +193,7 @@ function RosterEdit() {
     inactiveMembers,
     removeInactiveMember,
     inactiveToActive,
+    vibeCodingMode,
   } = useAppStore((state) => ({
     ensembleMembers: state.ensembleMembers,
     removeMember: state.removeMember,
@@ -190,6 +207,7 @@ function RosterEdit() {
     inactiveMembers: state.inactiveMembers,
     removeInactiveMember: state.removeInactiveMember,
     inactiveToActive: state.inactiveToActive,
+    vibeCodingMode: state.vibeCodingMode,
   }));
 
   const currentDriver = getCurrentDriver({ ensembleMembers, currentRotation });
@@ -247,7 +265,7 @@ function RosterEdit() {
             <div className="flex gap-2 flex-wrap px-3">
               {ensembleMembers.map((member) => (
                 <Badge key={member.id} className="text-2xl">
-                  {member.id === currentDriver.id && (
+                  {!vibeCodingMode && member.id === currentDriver.id && (
                     <WheelIcon className="w-6 h-6" />
                   )}
                   {member.id === currentNavigator.id && (

--- a/src/pages/Handoff.tsx
+++ b/src/pages/Handoff.tsx
@@ -29,6 +29,7 @@ export function Handoff() {
     previousDriver,
     nextDriver,
     startTurn,
+    vibeCodingMode,
   } = useAppStore((state) => ({
     ensembleMembers: state.ensembleMembers,
     currentRotation: state.currentRotation,
@@ -36,6 +37,7 @@ export function Handoff() {
     previousDriver: state.previousDriver,
     nextDriver: state.nextDriver,
     startTurn: state.startTurn,
+    vibeCodingMode: state.vibeCodingMode,
   }));
   const currentDriver = getCurrentDriver({ currentRotation, ensembleMembers });
   const currentNavigator = getCurrentNavigator({
@@ -74,21 +76,23 @@ export function Handoff() {
               <CloseIcon className="w-10 h-10 ml-2 text-red-500" />
             </Button>
           </div>
-          <div className="flex items-center">
-            <WheelIcon className="w-24 h-24 text-white" />
-            <span className="text-white text-6xl ml-5">
-              {currentDriver.name}
-            </span>
-            <Button
-              className="ml-5 text-5xl h-19 hover:bg-zinc-700"
-              onClick={() => {
-                removeMember({ id: currentDriver.id });
-              }}
-            >
-              <p>Away</p>
-              <CloseIcon className="w-10 h-10 ml-2 text-red-500" />
-            </Button>
-          </div>
+          {!vibeCodingMode && (
+            <div className="flex items-center">
+              <WheelIcon className="w-24 h-24 text-white" />
+              <span className="text-white text-6xl ml-5">
+                {currentDriver.name}
+              </span>
+              <Button
+                className="ml-5 text-5xl h-19 hover:bg-zinc-700"
+                onClick={() => {
+                  removeMember({ id: currentDriver.id });
+                }}
+              >
+                <p>Away</p>
+                <CloseIcon className="w-10 h-10 ml-2 text-red-500" />
+              </Button>
+            </div>
+          )}
           <Button
             className="h-16 hover:bg-zinc-700"
             onClick={() => {

--- a/src/pages/TimerOverlay.tsx
+++ b/src/pages/TimerOverlay.tsx
@@ -9,7 +9,12 @@ import {
   getCurrentNavigator,
   useAppStore,
 } from '../state.ts/defaultState';
-import { CoffeeIcon, NavigatorIcon, WheelIcon } from '@/components/icons/icons';
+import {
+  CoffeeIcon,
+  NavigatorIcon,
+  VibeModeIcon,
+  WheelIcon,
+} from '@/components/icons/icons';
 
 export function TimerOverlay() {
   const {
@@ -21,6 +26,7 @@ export function TimerOverlay() {
     currentMode,
     endBreak,
     goToEdit,
+    vibeCodingMode,
   } = useAppStore((state) => ({
     setTimeRemaining: state.setTimeRemaining,
     timeRemaining: state.timeRemaining,
@@ -30,6 +36,7 @@ export function TimerOverlay() {
     currentMode: state.currentMode,
     endBreak: state.endBreak,
     goToEdit: state.goToEdit,
+    vibeCodingMode: state.vibeCodingMode,
   }));
 
   useEffect(() => {
@@ -97,6 +104,7 @@ export function TimerOverlay() {
           currentDriver={currentDriver}
           currentMode={currentMode}
           currentNavigator={currentNavigator}
+          vibeCodingMode={vibeCodingMode}
         />
         <BreakDisplay currentMode={currentMode} />
         <div className="">
@@ -116,20 +124,30 @@ function TimerDisplay({
   currentDriver,
   currentNavigator,
   currentMode,
+  vibeCodingMode,
 }: {
   currentDriver: EnsembleMember;
   currentNavigator: EnsembleMember;
   currentMode: EnsembleModes;
+  vibeCodingMode: boolean;
 }) {
   if (currentMode !== 'timer') {
     return;
   }
   return (
     <>
-      <div className="flex items-center">
-        <WheelIcon className="w-6 h-6 " />
-        <span className=" text-4xl font-light pl-3">{currentDriver.name}</span>
-      </div>
+      {!vibeCodingMode ? (
+        <div className="flex items-center">
+          <WheelIcon className="w-6 h-6 " />
+          <span className="text-4xl font-light pl-3">
+            {currentDriver.name}
+          </span>
+        </div>
+      ) : (
+        <div className="flex items-center justify-center">
+          <VibeModeIcon className="w-12 h-12 text-yellow-400" />
+        </div>
+      )}
       <div className="flex items-center">
         <NavigatorIcon className="w-6 h-6" />
         <span className="text-4xl font-light pl-3">

--- a/src/pages/TimerOverlay.tsx
+++ b/src/pages/TimerOverlay.tsx
@@ -145,7 +145,7 @@ function TimerDisplay({
         </div>
       ) : (
         <div className="flex items-center justify-center">
-          <VibeModeIcon className="w-12 h-12 text-yellow-400" />
+          <VibeModeIcon className="w-12 h-12 text-yellow-400" title="Vibe Coding Mode Active" />
         </div>
       )}
       <div className="flex items-center">

--- a/src/state.ts/defaultState.ts
+++ b/src/state.ts/defaultState.ts
@@ -45,6 +45,8 @@ export type AppStore = {
   takeBreak: () => void;
   endBreak: () => void;
   goToEdit: () => void;
+  vibeCodingMode: boolean;
+  toggleVibeCodingMode: () => void;
 };
 
 export const useAppStore = create<AppStore>()(
@@ -61,6 +63,9 @@ export const useAppStore = create<AppStore>()(
       rotationsPerBreak: 10,
       currentRotation: 1000000, // Start at high rotation so we do not get into negative number logic
       breakRotation: 0,
+      vibeCodingMode: false,
+      toggleVibeCodingMode: () => 
+        set((state) => ({ vibeCodingMode: !state.vibeCodingMode })),
       setBreakRotation: (breakRotation) => set(() => ({ breakRotation })),
       setRotationsPerBreak: (rotations) =>
         set(() => ({ rotationsPerBreak: rotations })),
@@ -184,6 +189,7 @@ export const useAppStore = create<AppStore>()(
         breakLength: state.breakLength,
         timerLength: state.timerLength,
         inactiveMembers: state.inactiveMembers,
+        vibeCodingMode: state.vibeCodingMode,
       }),
     },
   ),


### PR DESCRIPTION
## Summary
- Add toggle in Options for entering "vibe coding mode"
- Hide driver role when in vibe coding mode
- Show cool sunglasses icon in timer overlay
- Add vibeCodingMode state to persist user preference

## Test plan
1. Open the app and navigate to the Options section
2. Toggle "Vibe Coding Mode" on and verify the driver icon disappears
3. Start a timer session and verify only the navigator is shown with sunglasses icon
4. End timer session and verify Handoff screen shows only navigator
5. Restart the app and verify vibe coding mode setting persists

🤖 Generated with [Claude Code](https://claude.ai/code)